### PR TITLE
Add /current/ and /devel/ redirections

### DIFF
--- a/src/pages/404.html
+++ b/src/pages/404.html
@@ -21,7 +21,11 @@
           "/apps/apiviewer"     : "https://qooxdoo.org/qxl.apiviewer",     
           "/apps/demobrowser"   : "https://qooxdoo.org/qxl.demobrowser",   
           "/apps/widgetbrowser" : "https://qooxdoo.org/qxl.widgetbrowser",
-          "/apps/mobileshowcase": "https://qooxdoo.org/qxl.mobileshowcase"
+          "/apps/mobileshowcase": "https://qooxdoo.org/qxl.mobileshowcase",
+	  "/current/playground" : "https://qooxdoo.org/qxl.playground",  
+	  "/devel/playground" 	: "https://qooxdoo.org/qxl.playground",
+	  "/current/api" 	: "https://qooxdoo.org/qxl.apiviewer",  
+	  "/devel/api" 		: "https://qooxdoo.org/qxl.apiviewer",   	      
         };
       
       if (urlMap[path])


### PR DESCRIPTION
so that older links (for example, in stackoverflow questions) are still working